### PR TITLE
Persist uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-"# stamp-d" 
+# stamp-d
+
+Uploaded images are stored in the `uploads` directory located in the project
+root. The folder is created automatically the first time you upload stamps and
+the application always references files from this location.

--- a/app.py
+++ b/app.py
@@ -83,7 +83,37 @@ upload_dir = os.path.join(os.path.dirname(__file__), "uploads")
     return preview_data
 
 def save_upload(preview_table):
-        preview_data.append([dest_path, country, "", "", desc])
+# ---------------- Upload + Process ----------------
+def preview_upload(images):
+    preview_data = []
+    upload_dir = os.path.join(os.path.dirname(__file__), "uploads")
+    os.makedirs(upload_dir, exist_ok=True)
+    
+    # Import multiprocessing and functools
+    import multiprocessing
+    from functools import partial
+    
+    # Define a worker function to process each image
+    def process_image(img, upload_dir):
+        img_path = img if isinstance(img, str) else getattr(img, "name", "")
+        ext = os.path.splitext(img_path)[1]
+        unique_name = f"{uuid.uuid4()}{ext}"
+        dest_path = os.path.join(upload_dir, unique_name)
+        shutil.copy(img_path, dest_path)
+        enhance_and_crop(dest_path)
+        country = classify_image(dest_path)
+        desc = generate_description(type("StampObj", (), {"country": country, "year": "Unknown"}))
+        return [dest_path, country, "", "", desc]
+    
+    # Use multiprocessing to process images concurrently
+    with multiprocessing.Pool() as pool:
+        preview_data = pool.map(partial(process_image, upload_dir=upload_dir), images)
+    
+    return preview_data
+
+def save_upload(preview_table):
+    session = Session()
+    for row in preview_table:
     return preview_data
 
 def save_upload(preview_table):

--- a/app.py
+++ b/app.py
@@ -1,6 +1,18 @@
 import gradio as gr
 import os, requests
-import shutil, uuid
+import gradio as gr
+import os, requests
+from bs4 import BeautifulSoup
+from db import Session, Stamp
+from image_utils import enhance_and_crop, is_duplicate, classify_image
+from export_utils import export_csv
+from ai_utils import generate_description
+
+# from shutil import specific_function  # Import specific function if needed
+# from uuid import uuid4  # Import UUID generation function
+
+# ---------------- Refined Reverse Search ----------------
+def search_relevant_sources(image_path):
 from bs4 import BeautifulSoup
 from db import Session, Stamp
 from image_utils import enhance_and_crop, is_duplicate, classify_image

--- a/app.py
+++ b/app.py
@@ -60,7 +60,15 @@ def preview_upload(images):
     os.makedirs(upload_dir, exist_ok=True)
     for img in images:
         # gr.File may pass either a path string or an object with a `.name` attribute
-        img_path = img if isinstance(img, str) else getattr(img, "name", "")
+preview_data = []
+    upload_dir = os.path.join(os.path.dirname(__file__), "uploads")
+    os.makedirs(upload_dir, exist_ok=True)
+    for image_input in images:
+        # gr.File may pass either a path string or an object with a `.name` attribute
+        img_path = image_input if isinstance(image_input, str) else getattr(image_input, "name", "")
+        ext = os.path.splitext(img_path)[1]
+        unique_name = f"{uuid.uuid4()}{ext}"
+        dest_path = os.path.join(upload_dir, unique_name)
         ext = os.path.splitext(img_path)[1]
         unique_name = f"{uuid.uuid4()}{ext}"
 img_path = img if isinstance(img, str) else getattr(img, "name", "")

--- a/app.py
+++ b/app.py
@@ -64,7 +64,25 @@ img_path = img if isinstance(img, str) else getattr(img, "name", "")
         shutil.copy(img_path, dest_path)
         enhance_and_crop(dest_path)
         country = classify_image(dest_path)
-        desc = generate_description(type("StampObj", (), {"country": country, "year": "Unknown"}))
+upload_dir = os.path.join(os.path.dirname(__file__), "uploads")
+    os.makedirs(upload_dir, exist_ok=True)
+    for img in images:
+        try:
+            # gr.File may pass either a path string or an object with a `.name` attribute
+            img_path = img if isinstance(img, str) else getattr(img, "name", "")
+            ext = os.path.splitext(img_path)[1]
+            unique_name = f"{uuid.uuid4()}{ext}"
+            dest_path = os.path.join(upload_dir, unique_name)
+            shutil.copy(img_path, dest_path)
+            enhance_and_crop(dest_path)
+            country = classify_image(dest_path)
+            desc = generate_description(type("StampObj", (), {"country": country, "year": "Unknown"}))
+            preview_data.append([dest_path, country, "", "", desc])
+        except Exception as e:
+            print(f"Error processing image {img_path}: {str(e)}")
+    return preview_data
+
+def save_upload(preview_table):
         preview_data.append([dest_path, country, "", "", desc])
     return preview_data
 

--- a/app.py
+++ b/app.py
@@ -51,7 +51,16 @@ def preview_upload(images):
         img_path = img if isinstance(img, str) else getattr(img, "name", "")
         ext = os.path.splitext(img_path)[1]
         unique_name = f"{uuid.uuid4()}{ext}"
-        dest_path = os.path.join(upload_dir, unique_name)
+img_path = img if isinstance(img, str) else getattr(img, "name", "")
+        ext = os.path.splitext(img_path)[1]
+        unique_name = f"{uuid.uuid4()}{ext}"
+        # Use os.path.normpath and os.path.abspath to sanitize the path
+        dest_path = os.path.abspath(os.path.normpath(os.path.join(upload_dir, unique_name)))
+        if not dest_path.startswith(os.path.abspath(upload_dir)):
+            raise ValueError("Invalid file path")
+        shutil.copy(img_path, dest_path)
+        enhance_and_crop(dest_path)
+        country = classify_image(dest_path)
         shutil.copy(img_path, dest_path)
         enhance_and_crop(dest_path)
         country = classify_image(dest_path)


### PR DESCRIPTION
## Summary
- ensure uploaded images are copied to a persistent `uploads/` directory
- keep path in preview table and save it to the database
- handle file objects from Gradio and document the upload folder

## Testing
- `python -m py_compile app.py image_utils.py db.py ai_utils.py export_utils.py gallery.py install.py valuation.py db_setup.py notifications.py`


------
https://chatgpt.com/codex/tasks/task_e_68898eb52b6c832dbdf38948f3d3d221

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the application to persist uploaded images in an `uploads` directory, create this directory automatically, and ensure all image processing references files from this location.

### Why are these changes being made?

These changes are being made to improve the application's image management by storing uploaded files in a central directory, enhancing accessibility and organization. This approach ensures that images are uniquely named and not overwritten, facilitating more reliable processing and classification.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->