### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 import gradio as gr
 import os, requests
 import shutil, uuid
+from werkzeug.utils import secure_filename
 from bs4 import BeautifulSoup
 from db import Session, Stamp
 from image_utils import enhance_and_crop, is_duplicate, classify_image
@@ -47,7 +48,8 @@ def preview_upload(images):
     upload_dir = "uploads"
     os.makedirs(upload_dir, exist_ok=True)
     for img in images:
-        ext = os.path.splitext(img)[1]
+        sanitized_name = secure_filename(os.path.basename(img))
+        ext = os.path.splitext(sanitized_name)[1]
         unique_name = f"{uuid.uuid4()}{ext}"
         dest_path = os.path.join(upload_dir, unique_name)
         shutil.copy(img, dest_path)


### PR DESCRIPTION
Potential fix for [https://github.com/940smiley/stamp-d/security/code-scanning/3](https://github.com/940smiley/stamp-d/security/code-scanning/3)

To fix the issue, we need to validate and sanitize the user-provided file paths before using them to construct `dest_path`. The best approach is to use `os.path.basename` to extract only the base name of the file, ensuring that no directory traversal characters (`../`) are included. Additionally, we can use `werkzeug.utils.secure_filename` to sanitize the file name further, removing any special characters that could lead to unintended behavior.

Changes to make:
1. Import `secure_filename` from `werkzeug.utils`.
2. Use `secure_filename` to sanitize the file name extracted from `img`.
3. Ensure that `dest_path` remains within the `uploads` directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
