### PR TITLE
Persist uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-"# stamp-d" 
+# stamp-d
+
+Uploaded images are stored in the `uploads` directory located in the project
+root. The folder is created automatically the first time you upload stamps and
+the application always references files from this location.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,18 @@
 import gradio as gr
 import os, requests
-import shutil, uuid
+import gradio as gr
+import os, requests
+from bs4 import BeautifulSoup
+from db import Session, Stamp
+from image_utils import enhance_and_crop, is_duplicate, classify_image
+from export_utils import export_csv
+from ai_utils import generate_description
+
+# from shutil import specific_function  # Import specific function from shutil if needed
+# from uuid import uuid4  # Import specific UUID function
+
+# ---------------- Refined Reverse Search ----------------
+def search_relevant_sources(image_path):
 from bs4 import BeautifulSoup
 from db import Session, Stamp
 from image_utils import enhance_and_crop, is_duplicate, classify_image

--- a/app.py
+++ b/app.py
@@ -60,7 +60,14 @@ def preview_upload(images):
 
         ext = os.path.splitext(img_path)[1]
         unique_name = f"{uuid.uuid4()}{ext}"
-        dest_path = os.path.join(upload_dir, unique_name)
+ext = os.path.splitext(img_path)[1]
+        unique_name = f"{uuid.uuid4()}{ext}"
+        # from werkzeug.utils import secure_filename
+        # Use secure_filename to sanitize the filename and prevent path traversal
+        dest_path = os.path.join(upload_dir, secure_filename(unique_name))
+        shutil.copy(img_path, dest_path)
+        enhance_and_crop(dest_path)
+        country = classify_image(dest_path)
         shutil.copy(img_path, dest_path)
         enhance_and_crop(dest_path)
         country = classify_image(dest_path)

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import gradio as gr
 import os, requests
+import shutil, uuid
 from bs4 import BeautifulSoup
 from db import Session, Stamp
 from image_utils import enhance_and_crop, is_duplicate, classify_image
@@ -43,11 +44,28 @@ def search_relevant_sources(image_path):
 # ---------------- Upload + Process ----------------
 def preview_upload(images):
     preview_data = []
+    upload_dir = os.path.join(os.path.dirname(__file__), "uploads")
+    os.makedirs(upload_dir, exist_ok=True)
     for img in images:
-        enhance_and_crop(img)
-        country = classify_image(img)
+        # gr.File may pass a path string, a dict with a name/path key, or an object with a `.name` attribute
+        if isinstance(img, str):
+            img_path = img
+        elif isinstance(img, dict):
+            img_path = img.get("path") or img.get("name") or ""
+        else:
+            img_path = getattr(img, "name", "")
+
+        if not img_path or not os.path.exists(img_path):
+            continue
+
+        ext = os.path.splitext(img_path)[1]
+        unique_name = f"{uuid.uuid4()}{ext}"
+        dest_path = os.path.join(upload_dir, unique_name)
+        shutil.copy(img_path, dest_path)
+        enhance_and_crop(dest_path)
+        country = classify_image(dest_path)
         desc = generate_description(type("StampObj", (), {"country": country, "year": "Unknown"}))
-        preview_data.append([img, country, "", "", desc])
+        preview_data.append([dest_path, country, "", "", desc])
     return preview_data
 
 def save_upload(preview_table):

--- a/app.py
+++ b/app.py
@@ -70,7 +70,21 @@ ext = os.path.splitext(img_path)[1]
         country = classify_image(dest_path)
         shutil.copy(img_path, dest_path)
         enhance_and_crop(dest_path)
-        country = classify_image(dest_path)
+ext = os.path.splitext(img_path)[1]
+        unique_name = f"{uuid.uuid4()}{ext}"
+        dest_path = os.path.join(upload_dir, unique_name)
+        try:
+            shutil.copy(img_path, dest_path)
+            enhance_and_crop(dest_path)
+            country = classify_image(dest_path)
+            desc = generate_description(type("StampObj", (), {"country": country, "year": "Unknown"}))
+            preview_data.append([dest_path, country, "", "", desc])
+        except (IOError, OSError) as e:
+            print(f"Error processing image {img_path}: {str(e)}")
+            continue
+    return preview_data
+
+def save_upload(preview_table):
         desc = generate_description(type("StampObj", (), {"country": country, "year": "Unknown"}))
         preview_data.append([dest_path, country, "", "", desc])
     return preview_data


### PR DESCRIPTION
## Summary
- ensure uploaded images are copied to a persistent `uploads/` directory
- keep path in preview table and save it to the database
- handle file objects from Gradio and document the upload folder
- support dict-based `gr.File` objects

## Testing
- `python -m py_compile app.py image_utils.py db.py ai_utils.py export_utils.py gallery.py install.py valuation.py db_setup.py notifications.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68898eb52b6c832dbdf38948f3d3d221