### PR TITLE
Fix reverse search error handling and export

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,28 +1,24 @@
 import gradio as gr
-import os, requests
+import os
+import requests
+from urllib.parse import quote_plus
 from bs4 import BeautifulSoup
 from db import Session, Stamp
-from image_utils import enhance_and_crop, is_duplicate, classify_image
+from image_utils import is_duplicate
 from export_utils import export_csv
-from ai_utils import generate_description
 
 # ---------------- Refined Reverse Search ----------------
 def search_relevant_sources(image_path):
     """Run refined searches for marketplaces and catalog sites."""
-    results = {"ebay": "", "colnect": "", "hipstamp": ""}
 
     if not image_path or not os.path.exists(image_path):
-        return "❌ Image not found.", "", "", "", ""
+        return "❌ Image not found.", "", "", ""
 
     # eBay sold listings
-    query = os.path.basename(image_path).replace("_", " ")
+    query = quote_plus(os.path.basename(image_path).replace("_", " "))
     ebay_url = f"https://www.ebay.com/sch/i.html?_nkw={query}&LH_Sold=1"
     colnect_url = f"https://colnect.com/en/stamps/list/{query}"
     hipstamp_url = f"https://www.hipstamp.com/search?keywords={query}&show=store_items"
-
-    results["ebay"] = f'<a href="{ebay_url}" target="_blank">eBay Sold Items for "{query}"</a>'
-    results["colnect"] = f'<a href="{colnect_url}" target="_blank">Colnect Matches for "{query}"</a>'
-    results["hipstamp"] = f'<a href="{hipstamp_url}" target="_blank">HipStamp Items for "{query}"</a>'
 
     # Optionally scrape eBay sold items for top match title
     try:
@@ -30,7 +26,7 @@ def search_relevant_sources(image_path):
         soup = BeautifulSoup(r.text, "html.parser")
         item = soup.select_one(".s-item__title")
         top_title = item.text if item else ""
-    except:
+    except requests.RequestException:
         top_title = ""
 
     return (
@@ -126,7 +122,7 @@ with gr.Blocks() as demo:
         suggested_title = gr.Textbox(label="Top Match Title from eBay")
         
         reverse_btn_upload.click(
-            lambda idx, table: search_relevant_sources(table[int(idx)][0]) if 0 <= int(idx) < len(table) else ("❌ Invalid index","","","",""),
+            lambda idx, table: search_relevant_sources(table[int(idx)][0]) if 0 <= int(idx) < len(table) else ("❌ Invalid index","","",""),
             inputs=[idx_input, preview_table],
             outputs=[ebay_frame, colnect_frame, hipstamp_frame, suggested_title]
         )
@@ -169,7 +165,7 @@ with gr.Blocks() as demo:
         suggested_title_g = gr.Textbox(label="Top eBay Match Title")
 
         reverse_btn_gallery.click(
-            lambda stamp_id: search_relevant_sources(Session().query(Stamp).get(int(stamp_id)).image_path) if stamp_id else ("❌ No stamp selected","","","",""),
+            lambda stamp_id: search_relevant_sources(Session().query(Stamp).get(int(stamp_id)).image_path) if str(stamp_id).isdigit() else ("❌ No stamp selected","","",""),
             inputs=stamp_id,
             outputs=[ebay_frame_g, colnect_frame_g, hipstamp_frame_g, suggested_title_g]
         )

--- a/db_setup.py
+++ b/db_setup.py
@@ -1,5 +1,5 @@
-from sqlalchemy import create_engine, Column, Integer, String, Date, Text
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import create_engine, Column, Integer, String, Text
+from sqlalchemy.orm import declarative_base
 
 DATABASE_URL = "postgresql+psycopg2://postgres:NewPassword123!@localhost/stampd"
 Base = declarative_base()

--- a/export_utils.py
+++ b/export_utils.py
@@ -4,7 +4,10 @@ from db import Session, Stamp
 def export_csv(path="export.csv"):
     session = Session()
     stamps = session.query(Stamp).all()
-    data = [s.__dict__ for s in stamps]
+    data = [
+        {column.name: getattr(s, column.name) for column in Stamp.__table__.columns}
+        for s in stamps
+    ]
     df = pd.DataFrame(data)
     df.to_csv(path, index=False)
     return path

--- a/image_utils.py
+++ b/image_utils.py
@@ -1,6 +1,8 @@
-import cv2, imagehash
+import cv2
+import imagehash
 from PIL import Image, ImageEnhance
-import numpy as np, os
+import numpy as np
+import os
 from sqlalchemy.orm import Session
 from db import Stamp
 
@@ -13,9 +15,10 @@ def enhance_and_crop(image_path):
     open_cv_img = np.array(img)
     gray = cv2.cvtColor(open_cv_img, cv2.COLOR_BGR2GRAY)
     coords = cv2.findNonZero(255 - gray)
-    x, y, w, h = cv2.boundingRect(coords)
-    cropped = img.crop((x, y, x + w, y + h))
-    cropped.save(image_path)
+    if coords is not None:
+        x, y, w, h = cv2.boundingRect(coords)
+        img = img.crop((x, y, x + w, y + h))
+    img.save(image_path)
     return image_path
 
 def is_duplicate(image_path, db_session: Session):

--- a/install.py
+++ b/install.py
@@ -1,4 +1,5 @@
-import subprocess, sys
+import subprocess
+import sys
 
 modules = [
     "gradio", "sqlalchemy", "psycopg2-binary", "pandas", "pillow", "opencv-python",

--- a/valuation.py
+++ b/valuation.py
@@ -8,8 +8,8 @@ def get_valuation(stamp_desc):
     prices = []
     for price in soup.select(".s-item__price"):
         try:
-            p = float(price.text.replace("$","").replace(",",""))
+            p = float(price.text.replace("$", "").replace(",", ""))
             prices.append(p)
-        except:
-            pass
+        except ValueError:
+            continue
     return sum(prices)/len(prices) if prices else 0


### PR DESCRIPTION
## Summary
- ensure reverse image search function returns the correct number of outputs
- URL encode queries and handle request errors
- fix image cropping when no non-zero pixels found
- export CSV without SQLAlchemy internals
- minor lint fixes

## Testing
- `ruff check app.py image_utils.py export_utils.py db_setup.py install.py valuation.py`
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6889f6ab2104832dadffe5c9bb1d8771