### PR TITLE
Fix reverse search error handling and export

### DIFF
--- a/db_setup.py
+++ b/db_setup.py
@@ -1,5 +1,5 @@
-from sqlalchemy import create_engine, Column, Integer, String, Date, Text
-from sqlalchemy.orm import declarative_base, sessionmaker
+from sqlalchemy import create_engine, Column, Integer, String, Text
+from sqlalchemy.orm import declarative_base
 
 DATABASE_URL = "postgresql+psycopg2://postgres:NewPassword123!@localhost/stampd"
 Base = declarative_base()

--- a/export_utils.py
+++ b/export_utils.py
@@ -4,7 +4,10 @@ from db import Session, Stamp
 def export_csv(path="export.csv"):
     session = Session()
     stamps = session.query(Stamp).all()
-    data = [s.__dict__ for s in stamps]
+    data = [
+        {column.name: getattr(s, column.name) for column in Stamp.__table__.columns}
+        for s in stamps
+    ]
     df = pd.DataFrame(data)
     df.to_csv(path, index=False)
     return path

--- a/image_utils.py
+++ b/image_utils.py
@@ -1,6 +1,8 @@
-import cv2, imagehash
+import cv2
+import imagehash
 from PIL import Image, ImageEnhance
-import numpy as np, os
+import numpy as np
+import os
 from sqlalchemy.orm import Session
 from db import Stamp
 
@@ -13,9 +15,10 @@ def enhance_and_crop(image_path):
     open_cv_img = np.array(img)
     gray = cv2.cvtColor(open_cv_img, cv2.COLOR_BGR2GRAY)
     coords = cv2.findNonZero(255 - gray)
-    x, y, w, h = cv2.boundingRect(coords)
-    cropped = img.crop((x, y, x + w, y + h))
-    cropped.save(image_path)
+    if coords is not None:
+        x, y, w, h = cv2.boundingRect(coords)
+        img = img.crop((x, y, x + w, y + h))
+    img.save(image_path)
     return image_path
 
 def is_duplicate(image_path, db_session: Session):

--- a/install.py
+++ b/install.py
@@ -1,4 +1,5 @@
-import subprocess, sys
+import subprocess
+import sys
 
 modules = [
     "gradio", "sqlalchemy", "psycopg2-binary", "pandas", "pillow", "opencv-python",

--- a/valuation.py
+++ b/valuation.py
@@ -8,8 +8,8 @@ def get_valuation(stamp_desc):
     prices = []
     for price in soup.select(".s-item__price"):
         try:
-            p = float(price.text.replace("$","").replace(",",""))
+            p = float(price.text.replace("$", "").replace(",", ""))
             prices.append(p)
-        except:
-            pass
+        except ValueError:
+            continue
     return sum(prices)/len(prices) if prices else 0


### PR DESCRIPTION
## Summary
- ensure reverse image search function returns the correct number of outputs
- URL encode queries and handle request errors
- fix image cropping when no non-zero pixels found
- export CSV without SQLAlchemy internals
- minor lint fixes
- handle gallery selection events properly

## Testing
- `ruff check app.py image_utils.py export_utils.py db_setup.py install.py valuation.py`
- `python -m py_compile app.py image_utils.py export_utils.py db_setup.py install.py valuation.py`


------
https://chatgpt.com/codex/tasks/task_e_6889f6ab2104832dadffe5c9bb1d8771