### PR TITLE
Add title parser to auto-fill stamp details

### DIFF
--- a/parsing_utils.py
+++ b/parsing_utils.py
@@ -1,0 +1,76 @@
+import re
+
+
+def parse_title(title: str):
+    """Extract probable year, country and denomination from an eBay title."""
+    if not title:
+        return "", "", ""
+
+    # Find year like 1850, 1999, 2012 etc
+    year_match = re.search(r"(18|19|20)\d{2}", title)
+    year = year_match.group(0) if year_match else ""
+
+    # Try to locate a denomination such as '5c', '10 p', '2.50$', etc.
+    denom_match = re.search(
+        r"\b\d+(?:[.,]\d+)?\s?(?:c|¢|p|d|fr|pf|\$|€|£|kr|sen|yen|mk|cts?|cent|cents)\b",
+        title,
+        re.IGNORECASE,
+    )
+    denom = denom_match.group(0).strip() if denom_match else ""
+
+    # Guess country using words around the year/denomination
+    country = ""
+    if year_match:
+        before = title[: year_match.start()]
+        after = title[year_match.end() :]
+        before_words = [w for w in re.sub(r"[^A-Za-z ]+", " ", before).split() if w]
+        if before_words:
+            filtered = [
+                w
+                for w in before_words
+                if not re.match(r"^\d", w)
+                and not re.fullmatch(
+                    r"c|¢|p|d|fr|pf|kr|sen|yen|mk|cts?|cent|cents",
+                    w.lower(),
+                )
+            ]
+            if filtered:
+                before_words = filtered
+            country = " ".join(before_words[-3:])
+        else:
+            after_clean = re.sub(r"[^A-Za-z0-9 ]+", " ", after)
+            after_tokens = after_clean.split()
+            result_words = []
+            for w in after_tokens:
+                if any(ch.isdigit() for ch in w):
+                    break
+                if w.lower() in {"stamp", "stamps"}:
+                    break
+                result_words.append(w)
+                if len(result_words) >= 3:
+                    break
+            if result_words:
+                country = " ".join(result_words)
+    elif denom_match:
+        before = title[: denom_match.start()]
+        before_words = [w for w in re.sub(r"[^A-Za-z ]+", " ", before).split() if w]
+        if before_words:
+            filtered = [
+                w
+                for w in before_words
+                if not re.match(r"^\d", w)
+                and not re.fullmatch(
+                    r"c|¢|p|d|fr|pf|kr|sen|yen|mk|cts?|cent|cents",
+                    w.lower(),
+                )
+            ]
+            if filtered:
+                before_words = filtered
+            country = " ".join(before_words[-3:])
+
+    if not country:
+        tokens = [t for t in re.sub(r"[^A-Za-z ]+", " ", title).split() if t]
+        if tokens:
+            country = tokens[0]
+
+    return year, country.title(), denom


### PR DESCRIPTION
## Summary
- parse probable year, country, and denomination from eBay titles
- auto-fill upload preview rows with parsed data
- update gallery edit boxes with parsed values when doing reverse search

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_688a0b7644ec832d811e57b1631cb162