### PR TITLE
Improve logging and gallery update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+## Stamp'd
+
+This is a simple stamp collection manager built with Gradio. It allows uploading
+stamp images, editing metadata inline, performing reverse image searches and
+exporting the collection.
+
+### Running
+
+```
+python app.py
+```
+
+Uploaded data is stored in `stampd.db`. Error logs are written to `app.log`.


### PR DESCRIPTION
## Summary
- update README
- add logging to `app.py`
- convert reverse search results to open in a new tab
- handle database errors
- automatically refresh gallery after saving

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a4638d134832d99facaef5a0aa1b2