### PR TITLE
Fix gallery reverse search

### DIFF
--- a/app.py
+++ b/app.py
@@ -20,11 +20,17 @@ logger = logging.getLogger(__name__)
 def search_sources(image_path):
     """Generate marketplace URLs based on an image file path."""
     logger.info(f"Attempting reverse search for image_path: {image_path}")
-    if not image_path or not os.path.exists(image_path):
+    SAFE_IMAGE_DIR = os.path.abspath("images")  # Change "images" to your actual safe directory
+    if not image_path:
         logger.error(f"Invalid image path for search: {image_path}")
         return "❌ No image", "❌ No image", "❌ No image"
+    # Normalize and validate the path
+    normalized_path = os.path.abspath(os.path.normpath(image_path))
+    if not normalized_path.startswith(SAFE_IMAGE_DIR) or not os.path.exists(normalized_path):
+        logger.error(f"Image path not allowed or does not exist: {image_path}")
+        return "❌ No image", "❌ No image", "❌ No image"
 
-    filename_without_ext = os.path.splitext(os.path.basename(image_path))[0]
+    filename_without_ext = os.path.splitext(os.path.basename(normalized_path))[0]
     query = filename_without_ext.replace("_", " ")
 
     ebay = f"https://www.ebay.com/sch/i.html?_nkw={query}&LH_Sold=1"

--- a/app.py
+++ b/app.py
@@ -18,12 +18,23 @@ logger = logging.getLogger(__name__)
 
 # ---------------- Reverse Search ----------------
 def search_sources(image_path):
+    """Generate marketplace URLs based on an image file path."""
+    logger.info(f"Attempting reverse search for image_path: {image_path}")
     if not image_path or not os.path.exists(image_path):
+        logger.error(f"Invalid image path for search: {image_path}")
         return "❌ No image", "❌ No image", "❌ No image"
-    query = os.path.basename(image_path).replace("_", " ")
+
+    filename_without_ext = os.path.splitext(os.path.basename(image_path))[0]
+    query = filename_without_ext.replace("_", " ")
+
     ebay = f"https://www.ebay.com/sch/i.html?_nkw={query}&LH_Sold=1"
     colnect = f"https://colnect.com/en/stamps/list/{query}"
     hip = f"https://www.hipstamp.com/search?keywords={query}&show=store_items"
+
+    logger.info(f"Generated eBay URL: {ebay}")
+    logger.info(f"Generated Colnect URL: {colnect}")
+    logger.info(f"Generated HipStamp URL: {hip}")
+
     return (
         f"<a href='{ebay}' target='_blank'>eBay Results</a>",
         f"<a href='{colnect}' target='_blank'>Colnect Results</a>",
@@ -33,6 +44,8 @@ def search_sources(image_path):
 # ---------------- Upload ----------------
 def preview_upload(images):
     rows = []
+    if not images:
+        return rows
     for path in images:
         thumb_html = path
         if os.path.exists(path):
@@ -42,8 +55,13 @@ def preview_upload(images):
                 img.save(buf, format="PNG")
             b64 = base64.b64encode(buf.getvalue()).decode()
             thumb_html = f"<img src='data:image/png;base64,{b64}' width='50'/>"
-        country = classify_image(path)
-        desc = generate_description(type("S", (), {"country": country, "year": "Unknown"}))
+        else:
+            logger.warning(f"File not found during preview: {path}")
+            thumb_html = "File not found"
+
+        country = classify_image(path) if os.path.exists(path) else "Unknown"
+        desc_obj = type("S", (), {"country": country, "year": "Unknown"})
+        desc = generate_description(desc_obj)
         rows.append([thumb_html, path, country, "", "", desc])
     return rows
 
@@ -52,10 +70,17 @@ def save_upload(preview_rows):
         return "❌ No rows to save"
     session = Session()
     try:
-        for _, path, country, denom, year, notes in preview_rows:
+        saved_count = 0
+        for row in preview_rows:
+            if len(row) < 6:
+                logger.warning(f"Skipping malformed row during save_upload: {row}")
+                continue
+            _, path, country, denom, year, notes = row
             if not os.path.exists(path):
+                logger.warning(f"File not found during save: {path}")
                 continue
             if is_duplicate(path, session):
+                logger.info(f"Skipping duplicate image: {path}")
                 continue
             stamp = Stamp(
                 image_path=path,
@@ -66,8 +91,9 @@ def save_upload(preview_rows):
                 description=notes
             )
             session.add(stamp)
+            saved_count += 1
         session.commit()
-        return "✅ Saved to database!"
+        return f"✅ Saved {saved_count} stamps to database!"
     except Exception as e:
         logger.exception("Error saving uploads")
         session.rollback()
@@ -96,19 +122,49 @@ def load_gallery_data():
 def update_gallery_table(new_table):
     """Update database with inline edits."""
     session = Session()
-    for row in new_table:
-        thumb, stamp_id, country, denom, year, notes = row
-        s = session.query(Stamp).get(int(stamp_id))
-        if s:
-            s.country, s.denomination, s.year, s.notes = country, denom, year, notes
-    session.commit()
-    return "✅ Changes saved inline!"
+    try:
+        for row in new_table:
+            if len(row) < 6:
+                logger.warning(f"Skipping malformed row during update_gallery_table: {row}")
+                continue
+            thumb, stamp_id, country, denom, year, notes = row
+            try:
+                stamp_id = int(stamp_id)
+            except (ValueError, TypeError):
+                logger.error(f"Invalid stamp_id encountered during update: {stamp_id}")
+                continue
 
-def load_details(stamp_id):
-    session = Session()
-    s = session.query(Stamp).get(int(stamp_id))
-    if not s:
+            s = session.query(Stamp).get(stamp_id)
+            if s:
+                s.country, s.denomination, s.year, s.notes = country, denom, year, notes
+            else:
+                logger.warning(f"Stamp with ID {stamp_id} not found for update.")
+        session.commit()
+        return "✅ Changes saved inline!"
+    except Exception:
+        logger.exception("Error updating gallery table")
+        session.rollback()
+        return "❌ Error saving changes"
+
+def load_details(selected_row_data):
+    """Return stamp details for a row selected in the gallery."""
+    if not selected_row_data or len(selected_row_data) < 2:
+        logger.warning("No row data or insufficient row data for load_details.")
         return "", None, "", "", "", ""
+
+    stamp_id_str = selected_row_data[1]
+    try:
+        stamp_id = int(stamp_id_str)
+    except (ValueError, TypeError):
+        logger.error(f"Invalid stamp ID from selected row: {stamp_id_str}")
+        return "", None, "", "", "", ""
+
+    session = Session()
+    s = session.query(Stamp).get(stamp_id)
+    if not s:
+        logger.warning(f"Stamp with ID {stamp_id} not found in database.")
+        return "", None, "", "", "", ""
+
     return s.id, s.image_path, s.country, s.denomination, s.year, s.notes
 
 # ---------------- Export ----------------
@@ -154,22 +210,31 @@ with gr.Blocks(css="#app-container{padding:10px;}") as demo:
         gallery_table.change(update_gallery_table, gallery_table, None)  # Auto-save on change
         btn_refresh.click(load_gallery_data, outputs=gallery_table)
 
-        stamp_id = gr.Textbox(label="Stamp ID", interactive=False)
-        image_display = gr.Image(label="Image")
+        stamp_id_display = gr.Textbox(label="Selected Stamp ID", interactive=False)
+        image_display = gr.Image(label="Selected Stamp Image", type="filepath")
         btn_rev_gallery = gr.Button("🔎 Reverse Search Selected")
         ebay_iframe_g = gr.HTML()
         colnect_iframe_g = gr.HTML()
         hip_iframe_g = gr.HTML()
 
+        def _on_gallery_select(evt: gr.SelectData, table):
+            if not evt or table is None:
+                return "", None, "", "", "", ""
+            idx = evt.index if isinstance(evt.index, int) else evt.index[0]
+            if idx is None or idx >= len(table):
+                return "", None, "", "", "", ""
+            return load_details(table[idx])
+
         gallery_table.select(
-            lambda evt: load_details(evt.value[1]) if evt else ("", None, "", "", "", ""),
-            None,
-            [stamp_id, image_display, gr.Textbox(visible=False), gr.Textbox(visible=False), gr.Textbox(visible=False), gr.Textbox(visible=False)]
+            _on_gallery_select,
+            [gallery_table],
+            [stamp_id_display, image_display, gr.Textbox(visible=False), gr.Textbox(visible=False), gr.Textbox(visible=False), gr.Textbox(visible=False)]
         )
 
         btn_rev_gallery.click(
-            lambda id: search_sources(Session().query(Stamp).get(int(id)).image_path) if id else ("❌", "❌", "❌"),
-            inputs=stamp_id, outputs=[ebay_iframe_g, colnect_iframe_g, hip_iframe_g]
+            lambda img_path: search_sources(img_path) if img_path else ("❌", "❌", "❌"),
+            inputs=image_display,
+            outputs=[ebay_iframe_g, colnect_iframe_g, hip_iframe_g]
         )
 
     # --- Export Tab ---


### PR DESCRIPTION
## Summary
- add logging and validation to `search_sources`
- improve upload preview and saving robustness
- validate data in gallery table updates
- revise `load_details` to take row data
- handle gallery selection properly and trigger reverse search using image path

## Testing
- `python -m py_compile app.py ai_utils.py db.py export_utils.py gallery.py image_utils.py parsing_utils.py notifications.py valuation.py db_setup.py`

------
https://chatgpt.com/codex/tasks/task_e_688ac4fef6b0832da68705e3f55d59c5