### PR TITLE
Revamp Stamp'd app with modular UI, AI scanning, and exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+logs/
+backups/
+*.db
+!.gitignore

--- a/ai_utils.py
+++ b/ai_utils.py
@@ -27,7 +27,18 @@ def _query_ollama_vision(image_path: str, prompt: str) -> str | None:
     Returns the textual response or ``None`` if the request fails.
     """
     try:
-        with open(image_path, "rb") as f:
+Returns the textual response or ``None`` if the request fails.
+    """
+    try:
+        # import os.path
+        # Use os.path.abspath and os.path.join to create a safe, absolute file path
+        safe_path = os.path.abspath(os.path.join(os.path.dirname(__file__), image_path))
+        if not safe_path.startswith(os.path.dirname(__file__)):
+            return None  # Path is outside the allowed directory
+        with open(safe_path, "rb") as f:
+            b64 = base64.b64encode(f.read()).decode()
+        payload = {
+            "model": CONFIG.get("ai_model", "phi3"),
             b64 = base64.b64encode(f.read()).decode()
         payload = {
             "model": CONFIG.get("ai_model", "phi3"),

--- a/app.py
+++ b/app.py
@@ -1,115 +1,267 @@
-# app.py — Main application for Stamp'd
+"""Main Gradio application for Stamp'd.
+
+The UI exposes functionality for scanning stamps using a local Ollama
+model, managing the gallery, exporting data and adjusting settings.  The
+implementation focuses on being robust in a variety of environments – if
+optional dependencies are missing the features gracefully degrade.
+"""
+
+from __future__ import annotations
 
 import os
-import gradio as gr
+import shutil
 import logging
-from db_utils import init_db, get_all_stamps, insert_stamp, update_stamp, get_stamp_by_id
-from ai_utils import generate_description, classify_image
-from export_utils import export_csv
-from reverse_search import search_sources
-from config import *
+from typing import List, Dict, Any
 
-# Ensure folders exist
-for dir_path in [IMAGES_DIR, THUMBNAILS_DIR, LOGS_DIR, BACKUP_DIR]:
-    os.makedirs(dir_path, exist_ok=True)
+import gradio as gr
 
-# Logging
+from ai_utils import generate_metadata
+from db_utils import (
+    init_db,
+    insert_many,
+    get_all_stamps,
+    get_stamp,
+    update_stamp,
+)
+from export_utils import export_csv, export_xlsx, export_pdf
+from config import CONFIG, load_config, save_config, IMAGES_DIR, LOGS_DIR
+
+# ---------------------------------------------------------------------------
+# Logging and database initialisation
+# ---------------------------------------------------------------------------
+os.makedirs(LOGS_DIR, exist_ok=True)
 logging.basicConfig(
     filename=os.path.join(LOGS_DIR, "errors.log"),
     level=logging.ERROR,
-    format="%(asctime)s:%(levelname)s:%(message)s"
+    format="%(asctime)s %(levelname)s %(message)s",
 )
 
-# Initialize DB
 init_db()
 
-def sync_and_autofill():
-    previews = []
-    for fname in os.listdir(IMAGES_DIR):
-        if fname.lower().endswith((".png", ".jpg", ".jpeg")):
-            img_path = os.path.join(IMAGES_DIR, fname)
-            stamp_data = {
-                "image_path": img_path,
-                "country": "",
-                "denomination": "",
-                "year": "",
-                "notes": "",
-                "catalog_number": "",
-                "mint_used": "",
-                "description": generate_description(img_path),
-                "ai_classification": classify_image(img_path)
-            }
-            previews.append(stamp_data)
-    return previews
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
 
-def save_previews(preview_list):
-    for entry in preview_list:
-        insert_stamp(entry)
-    return "✅ Saved new stamps!"
+def _scan_paths(paths: List[str], progress: gr.Progress | None = None) -> List[Dict[str, Any]]:
+    """Scan *paths* and return metadata records."""
+    records = []
+    total = len(paths)
+    for idx, path in enumerate(paths, 1):
+        try:
+            md = generate_metadata(path)
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.error("scan failed for %s: %s", path, exc)
+            md = {"name": "", "country": "", "denomination": "", "description": ""}
+        record = {
+            "image_path": path,
+            "stamp_name": md.get("name", ""),
+            "country": md.get("country", ""),
+            "denomination": md.get("denomination", ""),
+            "description": md.get("description", ""),
+        }
+        records.append(record)
+        if progress is not None:
+            try:
+                progress(idx / total)
+            except Exception:
+                pass
+    return records
 
-def reverse_image_lookup(image_path):
-    try:
-        return search_sources(image_path)
-    except Exception as e:
-        logging.error(f"Reverse search error: {str(e)}")
-        return ["❌"] * 4
 
-def refresh_gallery():
-    return get_all_stamps()
+def upload_and_scan(files: List[Any], progress: gr.Progress | None = None) -> List[Dict[str, Any]]:
+    """Handle uploaded files and return scanned metadata."""
+    paths = []
+    for f in files:
+        dest = os.path.join(IMAGES_DIR, os.path.basename(f.name))
+        shutil.copy(f.name, dest)
+        paths.append(dest)
+    return _scan_paths(paths, progress)
 
-def populate_details(stamp_id):
-    return get_stamp_by_id(stamp_id)
 
-def update_stamp_details(stamp_id, country, denomination, year, notes, catalog, mint_used):
-    return update_stamp(stamp_id, country, denomination, year, notes, catalog, mint_used)
+def scan_and_sync_folder(progress: gr.Progress | None = None) -> List[Dict[str, Any]]:
+    """Scan all images from ``IMAGES_DIR`` not yet in the database."""
+    existing = {s.image_path for s in get_all_stamps()}
+    paths = [
+        os.path.join(IMAGES_DIR, f)
+        for f in os.listdir(IMAGES_DIR)
+        if f.lower().endswith((".png", ".jpg", ".jpeg")) and os.path.join(IMAGES_DIR, f) not in existing
+    ]
+    return _scan_paths(paths, progress)
 
-# === UI ===
-with gr.Blocks(title="Stamp’d") as demo:
-    gr.Markdown("# 📬 Stamp’d — Smart Stamp Cataloging")
 
-    with gr.Tab("📂 Sync & Autofill"):
-        sync_btn = gr.Button("🔁 Sync Folder and Autofill")
-        preview_list = gr.Dataframe(headers=["image_path", "country", "denomination", "year", "notes", "catalog_number", "mint_used", "description", "ai_classification"])
-        save_btn = gr.Button("💾 Save to DB")
-        sync_status = gr.Textbox(label="Status")
+def save_scans(data: List[Dict[str, Any]]) -> str:
+    insert_many(data)
+    return f"Saved {len(data)} stamps"
 
-        sync_btn.click(fn=sync_and_autofill, outputs=preview_list)
-        save_btn.click(fn=save_previews, inputs=preview_list, outputs=sync_status)
 
-    with gr.Tab("🖼️ Gallery"):
-        gallery = gr.Dataframe(headers=["id", "thumb", "country", "denomination", "year", "catalog_number", "mint_used", "notes"])
-        refresh_btn = gr.Button("🔄 Refresh Gallery")
-        refresh_btn.click(fn=refresh_gallery, outputs=gallery)
+def load_gallery(search: str = "") -> List[List[Any]]:
+    stamps = get_all_stamps()
+    rows = []
+    for s in stamps:
+        if search and search.lower() not in (s.country or "").lower():
+            continue
+        rows.append([s.id, s.image_path, s.stamp_name, s.country, s.denomination])
+    return rows
 
+
+def populate_stamp(stamp_id: int) -> List[Any]:
+    s = get_stamp(stamp_id)
+    if not s:
+        return [stamp_id, None, "", "", "", ""]
+    return [s.id, s.image_path, s.stamp_name, s.country, s.denomination, s.description]
+
+
+def save_stamp_details(stamp_id, name, country, denomination, description):
+    update_stamp(
+        int(stamp_id),
+        stamp_name=name,
+        country=country,
+        denomination=denomination,
+        description=description,
+    )
+    return "Saved"
+
+
+def read_errors() -> str:
+    path = os.path.join(LOGS_DIR, "errors.log")
+    if not os.path.exists(path):
+        return ""
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def save_settings(ai_model, csv, xlsx, pdf, ebay, hipstamp, colnect, stampworld):
+    cfg = load_config()
+    cfg["ai_model"] = ai_model
+    cfg["export_options"] = {
+        "csv": csv,
+        "xlsx": xlsx,
+        "pdf": pdf,
+        "ebay": ebay,
+        "hipstamp": hipstamp,
+        "colnect": colnect,
+        "stampworld": stampworld,
+    }
+    save_config(cfg)
+    return "Settings saved"
+
+
+# ---------------------------------------------------------------------------
+# Gradio UI
+# ---------------------------------------------------------------------------
+with gr.Blocks(title="Stamp'd") as demo:
+    gr.Markdown("# 📬 Stamp'd — Smart Stamp Cataloging")
+
+    with gr.Tab("Scan"):
+        upload = gr.File(file_count="multiple", file_types=["image"])
+        with gr.Row():
+            scan_btn = gr.Button("Upload and Scan")
+            sync_btn = gr.Button("Scan and Sync Folder")
+        scan_progress = gr.JSON(label="Scan Results")
+        save_all = gr.Button("Save All")
+        scan_status = gr.Textbox(label="Status")
+
+        scan_btn.click(upload_and_scan, inputs=upload, outputs=scan_progress)
+        sync_btn.click(scan_and_sync_folder, outputs=scan_progress)
+        save_all.click(save_scans, inputs=scan_progress, outputs=scan_status)
+
+    with gr.Tab("Gallery"):
+        search = gr.Textbox(label="Search")
+        gallery = gr.Dataframe(headers=["ID", "Image", "Name", "Country", "Denomination"], interactive=False)
         selected_id = gr.Number(label="Selected ID", precision=0)
-        image = gr.Image()
+        image = gr.Image(label="Stamp")
+        name = gr.Textbox(label="Name")
         country = gr.Textbox(label="Country")
         denom = gr.Textbox(label="Denomination")
-        year = gr.Textbox(label="Year")
-        notes = gr.Textbox(label="Notes")
-        catalog = gr.Textbox(label="Catalog Number")
-        mint_used = gr.Textbox(label="Mint/Used")
-        update_status = gr.Textbox(label="Update Result")
+        desc = gr.Textbox(label="Description")
+        edit_btn = gr.Button("Edit")
+        save_btn = gr.Button("Save", visible=False)
+        nav_prev = gr.Button("Previous")
+        nav_next = gr.Button("Next")
+        save_msg = gr.Textbox(label="Status")
 
-        gallery.select(fn=populate_details, inputs=[selected_id],
-                       outputs=[selected_id, image, country, denom, year, notes, catalog, mint_used])
+        def refresh_gallery_cb(search_query):
+            return load_gallery(search_query)
 
-        update_btn = gr.Button("💾 Update Selected")
-        update_btn.click(fn=update_stamp_details,
-                         inputs=[selected_id, country, denom, year, notes, catalog, mint_used],
-                         outputs=update_status)
+        search.submit(refresh_gallery_cb, inputs=search, outputs=gallery)
+        demo.load(lambda: load_gallery(""), outputs=gallery)
 
-        reverse_btn = gr.Button("🔍 Reverse Image Search")
-        reverse_result = gr.HTML()
+        def gallery_select(evt: gr.SelectData):
+            stamp_id = gallery.value[evt.index[0]][0]
+            return populate_stamp(stamp_id)
 
-        reverse_btn.click(fn=reverse_image_lookup, inputs=[image], outputs=[reverse_result])
+        gallery.select(gallery_select, outputs=[selected_id, image, name, country, denom, desc])
 
-    with gr.Tab("📤 Export & Logs"):
-        export_btn = gr.Button("Export CSV")
-        export_msg = gr.Textbox()
-        export_btn.click(fn=export_csv, outputs=export_msg)
+        def enter_edit_mode():
+            return gr.update(visible=True), gr.update(visible=False)
 
-        log_viewer = gr.File(label="Error Log")
-        log_viewer.value = os.path.join(LOGS_DIR, "errors.log")
+        def save_current(stamp_id, name, country, denom, desc):
+            msg = save_stamp_details(stamp_id, name, country, denom, desc)
+            return (
+                gr.update(visible=False),
+                gr.update(visible=True),
+                msg,
+            )
 
-demo.launch(share=True)
+        edit_btn.click(enter_edit_mode, outputs=[save_btn, edit_btn])
+        save_btn.click(
+            save_current,
+            inputs=[selected_id, name, country, denom, desc],
+            outputs=[save_btn, edit_btn, save_msg],
+        )
+
+        def navigate(delta):
+            stamps = load_gallery("")
+            ids = [row[0] for row in stamps]
+            if selected_id.value in ids:
+                idx = ids.index(selected_id.value) + delta
+                idx = max(0, min(len(ids) - 1, idx))
+            else:
+                idx = 0
+            return populate_stamp(ids[idx])
+
+        nav_prev.click(lambda: navigate(-1), outputs=[selected_id, image, name, country, denom, desc])
+        nav_next.click(lambda: navigate(1), outputs=[selected_id, image, name, country, denom, desc])
+
+    with gr.Tab("Export"):
+        export_csv_btn = gr.Button("Export CSV", visible=CONFIG["export_options"].get("csv", True))
+        export_xlsx_btn = gr.Button("Export XLSX", visible=CONFIG["export_options"].get("xlsx", True))
+        export_pdf_btn = gr.Button("Export PDF", visible=CONFIG["export_options"].get("pdf", True))
+        export_status = gr.Textbox(label="Status")
+
+        export_csv_btn.click(lambda: export_csv(), outputs=export_status)
+        export_xlsx_btn.click(lambda: export_xlsx(), outputs=export_status)
+        export_pdf_btn.click(lambda: export_pdf(), outputs=export_status)
+
+    with gr.Tab("Settings"):
+        cfg = load_config()
+        ai_model = gr.Dropdown(["phi3", "custom", "manual"], value=cfg.get("ai_model", "phi3"), label="AI Model")
+        with gr.Group():
+            gr.Markdown("### Export options")
+            csv = gr.Checkbox(value=cfg["export_options"].get("csv", True), label="CSV")
+            xlsx = gr.Checkbox(value=cfg["export_options"].get("xlsx", True), label="XLSX")
+            pdf = gr.Checkbox(value=cfg["export_options"].get("pdf", True), label="PDF")
+            ebay = gr.Checkbox(value=cfg["export_options"].get("ebay", False), label="eBay")
+            hipstamp = gr.Checkbox(value=cfg["export_options"].get("hipstamp", False), label="HipStamp")
+            colnect = gr.Checkbox(value=cfg["export_options"].get("colnect", False), label="Colnect")
+            stampworld = gr.Checkbox(value=cfg["export_options"].get("stampworld", False), label="StampWorld")
+        save_settings_btn = gr.Button("Save Settings")
+        settings_status = gr.Textbox(label="Status")
+        save_settings_btn.click(
+            save_settings,
+            inputs=[ai_model, csv, xlsx, pdf, ebay, hipstamp, colnect, stampworld],
+            outputs=settings_status,
+        )
+
+    with gr.Tab("Errors"):
+        log_content = gr.Textbox(label="errors.log", lines=20)
+        demo.load(read_errors, outputs=log_content)
+
+# End of Blocks
+
+def run():  # pragma: no cover - manual start helper
+    demo.launch()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/app.py
+++ b/app.py
@@ -144,7 +144,16 @@ def scan_and_sync_folder(progress: gr.Progress | None = None) -> List[Dict[str, 
 
 
 def save_scans(data: List[Dict[str, Any]]) -> str:
-    insert_many(data)
+def save_scans(data: List[Dict[str, Any]]) -> str:
+    try:
+        insert_many(data)
+        return f"Saved {len(data)} stamps"
+    except Exception as e:
+        logging.error(f"Error saving scans: {str(e)}")
+        return f"Error saving scans: {str(e)}"
+
+
+def load_gallery(search: str = "") -> List[List[Any]]:
     return f"Saved {len(data)} stamps"
 
 

--- a/app.py
+++ b/app.py
@@ -154,7 +154,10 @@ def save_scans(data: List[Dict[str, Any]]) -> str:
 
 
 def load_gallery(search: str = "") -> List[List[Any]]:
-    return f"Saved {len(data)} stamps"
+# import html  # Used for HTML escaping to prevent XSS attacks
+def save_scans(data: List[Dict[str, Any]]) -> str:
+    insert_many(data)
+    return f"Saved {html.escape(str(len(data)))} stamps"
 
 
 def load_gallery(search: str = "") -> List[List[Any]]:

--- a/app.py
+++ b/app.py
@@ -50,7 +50,15 @@ def _scan_paths(paths: List[str], progress: gr.Progress | None = None) -> List[D
         try:
             md = generate_metadata(path)
         except Exception as exc:  # pragma: no cover - defensive
-            logging.error("scan failed for %s: %s", path, exc)
+try:
+            md = generate_metadata(path)
+        except Exception as exc:  # pragma: no cover - defensive
+            # import html
+            # Sanitize user input before logging to prevent log injection
+            logging.error("scan failed for %s: %s", html.escape(path), html.escape(str(exc)))
+            md = {"name": "", "country": "", "denomination": "", "description": ""}
+        record = {
+            "image_path": path,
             md = {"name": "", "country": "", "denomination": "", "description": ""}
         record = {
             "image_path": path,

--- a/app.py
+++ b/app.py
@@ -106,7 +106,19 @@ def upload_and_scan(files: List[Any], progress: gr.Progress | None = None) -> Li
     """Handle uploaded files and return scanned metadata."""
     paths = []
     for f in files:
-        dest = os.path.join(IMAGES_DIR, os.path.basename(f.name))
+# Import statements for secure file handling
+import os
+from werkzeug.utils import secure_filename  # Provides secure_filename() to sanitize filenames
+
+def upload_and_scan(files: List[Any], progress: gr.Progress | None = None) -> List[Dict[str, Any]]:
+    """Handle uploaded files and return scanned metadata."""
+    paths = []
+    for f in files:
+        safe_filename = secure_filename(os.path.basename(f.name))
+        dest = os.path.join(IMAGES_DIR, safe_filename)
+        shutil.copy(f.name, dest)
+        paths.append(dest)
+    return _scan_paths(paths, progress)
 paths = []
     for f in files:
         dest = os.path.join(IMAGES_DIR, os.path.basename(f.name))

--- a/app.py
+++ b/app.py
@@ -73,7 +73,15 @@ def upload_and_scan(files: List[Any], progress: gr.Progress | None = None) -> Li
     paths = []
     for f in files:
         dest = os.path.join(IMAGES_DIR, os.path.basename(f.name))
-        shutil.copy(f.name, dest)
+paths = []
+    for f in files:
+        dest = os.path.join(IMAGES_DIR, os.path.basename(f.name))
+        try:
+            shutil.copy(f.name, dest)
+            paths.append(dest)
+        except (IOError, OSError) as e:
+            logging.error(f"Error copying file {f.name}: {str(e)}")
+    return _scan_paths(paths, progress)
         paths.append(dest)
     return _scan_paths(paths, progress)
 

--- a/app.py
+++ b/app.py
@@ -284,6 +284,20 @@ with gr.Blocks(title="Stamp'd") as demo:
                 idx = max(0, min(len(ids) - 1, idx))
             else:
                 idx = 0
+inputs=[selected_id, name, country, denom, desc],
+            outputs=[save_btn, edit_btn, save_msg],
+        )
+
+        def navigate(delta):
+            stamps = load_gallery("")
+            ids = [row[0] for row in stamps]
+            if not ids:
+                return [None, None, "", "", "", ""]
+            if selected_id.value in ids:
+                idx = ids.index(selected_id.value) + delta
+                idx = max(0, min(len(ids) - 1, idx))
+            else:
+                idx = 0
             return populate_stamp(ids[idx])
 
         nav_prev.click(lambda: navigate(-1), outputs=[selected_id, image, name, country, denom, desc])

--- a/app.py
+++ b/app.py
@@ -71,7 +71,33 @@ try:
         if progress is not None:
             try:
                 progress(idx / total)
-            except Exception:
+# Import logging module to enable exception logging
+import logging
+
+def _scan_paths(paths: List[str], progress: gr.Progress | None = None) -> List[Dict[str, Any]]:
+    """Scan *paths* and return metadata records."""
+    records = []
+    total = len(paths)
+    for idx, path in enumerate(paths, 1):
+        try:
+            md = generate_metadata(path)
+        except Exception as exc:  # pragma: no cover - defensive
+            logging.error("scan failed for %s: %s", path, exc)
+            md = {"name": "", "country": "", "denomination": "", "description": ""}
+        record = {
+            "image_path": path,
+            "stamp_name": md.get("name", ""),
+            "country": md.get("country", ""),
+            "denomination": md.get("denomination", ""),
+            "description": md.get("description", ""),
+        }
+        records.append(record)
+        if progress is not None:
+            try:
+                progress(idx / total)
+            except Exception as e:
+                logging.exception("Error updating progress: %s", e, exc_info=True)
+    return records
                 pass
     return records
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,15 @@
+{
+  "ai_model": "phi3",
+  "export_options": {
+    "csv": true,
+    "xlsx": true,
+    "pdf": true,
+    "ebay": false,
+    "hipstamp": false,
+    "colnect": false,
+    "stampworld": false
+  },
+  "gallery": {
+    "enable_search": true
+  }
+}

--- a/config.py
+++ b/config.py
@@ -1,22 +1,62 @@
-# config.py - Central configuration for Stamp'd
+"""Configuration utilities for Stamp'd.
 
+Settings are stored in a JSON file so that the application can reload
+changes at runtime.  This module exposes helper functions to read and
+update that file as well as common path constants used throughout the
+project.
+"""
+
+from __future__ import annotations
+
+import json
 import os
+from typing import Any, Dict
 
-BASE_DIR = r"G:/stamp-d"
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+CONFIG_FILE = os.path.join(BASE_DIR, "config.json")
 
-# Paths
-DB_PATH = os.path.join(BASE_DIR, "stampd.db")
+# Default configuration written when no config file exists yet.
+DEFAULT_CONFIG: Dict[str, Any] = {
+    "ai_model": "phi3",
+    "export_options": {
+        "csv": True,
+        "xlsx": True,
+        "pdf": True,
+        "ebay": False,
+        "hipstamp": False,
+        "colnect": False,
+        "stampworld": False,
+    },
+    "gallery": {"enable_search": True},
+}
+
+
+def load_config() -> Dict[str, Any]:
+    """Load configuration from ``CONFIG_FILE``.  If the file does not
+    exist, ``DEFAULT_CONFIG`` is written to disk and returned."""
+    if not os.path.exists(CONFIG_FILE):
+        save_config(DEFAULT_CONFIG)
+    with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_config(cfg: Dict[str, Any]) -> None:
+    """Persist *cfg* to ``CONFIG_FILE``."""
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(cfg, f, indent=2)
+
+
+# Load configuration immediately for modules that simply need access to
+# values without wanting to manage file IO themselves.  Call ``load_config``
+# again if a refreshed copy is required.
+CONFIG = load_config()
+
+# Common paths --------------------------------------------------------------
+DB_PATH = os.environ.get("STAMPD_DB_PATH", os.path.join(BASE_DIR, "stampd.db"))
 IMAGES_DIR = os.path.join(BASE_DIR, "images")
 THUMBNAILS_DIR = os.path.join(BASE_DIR, "thumbnails")
 LOGS_DIR = os.path.join(BASE_DIR, "logs")
 BACKUP_DIR = os.path.join(BASE_DIR, "backups")
 
-# Feature toggles
-AUTO_SYNC = True
-SILENT_MODE = False
-DEFAULT_MODEL = "phi3"
-USE_OLLAMA = True
-USE_LM_STUDIO = True
-
-# Marketplace config
-MARKETPLACES = ["ebay", "colnect", "delcampe", "stampworld"]
+for path in (IMAGES_DIR, THUMBNAILS_DIR, LOGS_DIR, BACKUP_DIR):
+    os.makedirs(path, exist_ok=True)

--- a/db_utils.py
+++ b/db_utils.py
@@ -52,7 +52,43 @@ def insert_stamp(data: Dict[str, Any]) -> int:
     stamp = Stamp(**data)
     session.add(stamp)
     session.commit()
-    return stamp.id
+def insert_stamp(data: Dict[str, Any]) -> int:
+    session = Session()
+    try:
+        stamp = Stamp(**data)
+        session.add(stamp)
+        session.commit()
+        return stamp.id
+    except Exception as e:
+        session.rollback()
+        raise e
+    finally:
+        session.close()
+
+
+def insert_many(stamps: Iterable[Dict[str, Any]]) -> None:
+    session = Session()
+    try:
+        session.add_all([Stamp(**s) for s in stamps])
+        session.commit()
+    except Exception as e:
+        session.rollback()
+        raise e
+    finally:
+        session.close()
+
+
+def get_all_stamps() -> List[Stamp]:
+    session = Session()
+    try:
+        return session.query(Stamp).all()
+    except Exception as e:
+        raise e
+    finally:
+        session.close()
+
+
+def get_stamp(stamp_id: int) -> Stamp | None:
 
 
 def insert_many(stamps: Iterable[Dict[str, Any]]) -> None:

--- a/db_utils.py
+++ b/db_utils.py
@@ -1,11 +1,20 @@
-# db_utils.py — Database schema and setup for Stamp’d
+"""Database utilities for Stamp'd.
+
+This module defines the SQLAlchemy model used by the application and
+helper functions for common CRUD operations.
+"""
+
+from __future__ import annotations
 
 from sqlalchemy import Column, Integer, String, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
+from typing import Iterable, List, Dict, Any
+
 from config import DB_PATH
 
 Base = declarative_base()
+
 
 class Stamp(Base):
     __tablename__ = "stamps"
@@ -13,6 +22,7 @@ class Stamp(Base):
     id = Column(Integer, primary_key=True)
     image_path = Column(String, unique=True)
     thumbnail_path = Column(String)
+    stamp_name = Column(String)
     country = Column(String)
     denomination = Column(String)
     year = Column(String)
@@ -27,9 +37,46 @@ class Stamp(Base):
     listing_url = Column(String)
     price = Column(String)
 
+
 # Create engine and session
 engine = create_engine(f"sqlite:///{DB_PATH}")
 Session = sessionmaker(bind=engine)
 
-def init_db():
+
+def init_db() -> None:
     Base.metadata.create_all(engine)
+
+
+def insert_stamp(data: Dict[str, Any]) -> int:
+    session = Session()
+    stamp = Stamp(**data)
+    session.add(stamp)
+    session.commit()
+    return stamp.id
+
+
+def insert_many(stamps: Iterable[Dict[str, Any]]) -> None:
+    session = Session()
+    session.add_all([Stamp(**s) for s in stamps])
+    session.commit()
+
+
+def get_all_stamps() -> List[Stamp]:
+    session = Session()
+    return session.query(Stamp).all()
+
+
+def get_stamp(stamp_id: int) -> Stamp | None:
+    session = Session()
+    return session.query(Stamp).get(stamp_id)
+
+
+def update_stamp(stamp_id: int, **fields: Any) -> int:
+    session = Session()
+    stamp = session.query(Stamp).get(stamp_id)
+    if not stamp:
+        raise ValueError("Stamp not found")
+    for key, value in fields.items():
+        setattr(stamp, key, value)
+    session.commit()
+    return stamp_id

--- a/export_utils.py
+++ b/export_utils.py
@@ -1,209 +1,73 @@
-import config
+"""Export utilities for Stamp'd.
+
+Provides helpers to export the database contents to CSV, XLSX and PDF
+files.  Exports are written to the ``BACKUP_DIR`` configured in
+:mod:`config` and the absolute path of the created file is returned.
+"""
+
+from __future__ import annotations
+
 import os
-import csv
-import zipfile
 from datetime import datetime
-from db_utils import Session, Stamp
-from image_utils import generate_thumbnail
-import pandas as pd
+from typing import List
+
+from fpdf import FPDF
 from openpyxl import Workbook
-from openpyxl.drawing.image import Image as XLImage
-from config import BACKUP_DIR, DB_PATH, IMAGES_DIR
 
-EXPORT_FOLDER = "exports"
-os.makedirs(EXPORT_FOLDER, exist_ok=True)
+from db_utils import Session, Stamp
+from config import BACKUP_DIR
 
-def timestamp():
-    return datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
 
-# -------------------------
-# CSV Export
-# -------------------------
-def export_csv(filename=None):
-    """Export all stamps to CSV."""
+def _timestamp() -> str:
+    return datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def export_csv() -> str:
+    """Export all stamps to a CSV file and return the path."""
+    import csv
+
     session = Session()
-    stamps = session.query(Stamp).all()
-
-    if not filename:
-        filename = f"stampd_export_{timestamp()}.csv"
-    filepath = os.path.join(EXPORT_FOLDER, filename)
-
-    fields = [
-        "id", "image_path", "stamp_name", "catalog_number", "country", "color",
-        "denomination", "perforation", "format", "mint_used", "year", "description", "notes",
-        "collection", "listed", "marketplace", "listing_url", "price", "sold", "lot_number",
-        "listing_status", "created_at", "updated_at"
-    ]
-
-    with open(filepath, "w", newline="", encoding="utf-8") as csvfile:
-        writer = csv.writer(csvfile)
+    stamps: List[Stamp] = session.query(Stamp).all()
+    filepath = os.path.join(BACKUP_DIR, f"export_{_timestamp()}.csv")
+    fields = ["id", "image_path", "stamp_name", "country", "denomination", "description"]
+    with open(filepath, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
         writer.writerow(fields)
         for s in stamps:
             writer.writerow([getattr(s, f) for f in fields])
-
     return filepath
 
-# -------------------------
-# XLSX Export with Thumbnails
-# -------------------------
-def export_xlsx(filename=None, include_thumbnails=True):
-    """Export all stamps to XLSX with optional thumbnails."""
+
+def export_xlsx() -> str:
+    """Export all stamps to an XLSX file and return the path."""
     session = Session()
-    stamps = session.query(Stamp).all()
-
-    if not filename:
-        filename = f"stampd_export_{timestamp()}.xlsx"
-    filepath = os.path.join(EXPORT_FOLDER, filename)
-
+    stamps: List[Stamp] = session.query(Stamp).all()
     wb = Workbook()
     ws = wb.active
-    headers = [
-        "Thumbnail", "ID", "Stamp Name", "Catalog #", "Country", "Color",
-        "Denomination", "Perforation", "Format", "Mint/Used", "Year", "Description", "Notes",
-        "Collection", "Listed", "Marketplace", "Listing URL", "Price", "Sold", "Lot #",
-        "Listing Status", "Created", "Updated"
-    ]
+    headers = ["ID", "Image Path", "Name", "Country", "Denomination", "Description"]
     ws.append(headers)
-
     for s in stamps:
-        row = [
-            "", s.id, s.stamp_name, s.catalog_number, s.country, s.color,
-            s.denomination, s.perforation, s.format, s.mint_used, s.year,
-            s.description, s.notes, s.collection, s.listed, s.marketplace,
-            s.listing_url, s.price, s.sold, s.lot_number,
-            s.listing_status, s.created_at, s.updated_at
-        ]
-        ws.append(row)
-
-        # Optionally embed thumbnail
-        if include_thumbnails and os.path.exists(s.image_path):
-            try:
-                img = XLImage(s.image_path)
-                img.width = 64
-                img.height = 64
-                ws.add_image(img, f"A{ws.max_row}")
-            except Exception:
-                pass
-
+        ws.append([s.id, s.image_path, s.stamp_name, s.country, s.denomination, s.description])
+    filepath = os.path.join(BACKUP_DIR, f"export_{_timestamp()}.xlsx")
     wb.save(filepath)
     return filepath
 
-# -------------------------
-# Auto Backup with ZIP
-# -------------------------
-def auto_backup():
-    """Create a timestamped ZIP of CSV + XLSX exports for backup."""
-    csv_path = export_csv()
-    xlsx_path = export_xlsx()
 
-    zip_name = f"stampd_backup_{timestamp()}.zip"
-    zip_path = os.path.join(EXPORT_FOLDER, zip_name)
-    with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.write(csv_path, os.path.basename(csv_path))
-        zf.write(xlsx_path, os.path.basename(xlsx_path))
-
-    return zip_path
-
-# -------------------------
-# Batch Export by Filter
-# -------------------------
-def export_filtered(filter_field=None, filter_value=None, filename=None):
-    """Export filtered stamps to CSV by a specific field."""
+def export_pdf() -> str:
+    """Create a simple PDF catalogue with images and metadata."""
     session = Session()
-    query = session.query(Stamp)
-    if filter_field and filter_value:
-        query = query.filter(getattr(Stamp, filter_field) == filter_value)
-    stamps = query.all()
-
-    if not filename:
-        filename = f"stampd_export_{filter_field}_{filter_value}_{timestamp()}.csv"
-    filepath = os.path.join(EXPORT_FOLDER, filename)
-
-    fields = [
-        "id", "image_path", "stamp_name", "catalog_number", "country", "color",
-        "denomination", "perforation", "format", "mint_used", "year", "description", "notes",
-        "collection", "listed", "marketplace", "listing_url", "price", "sold", "lot_number",
-        "listing_status", "created_at", "updated_at"
-    ]
-
-    with open(filepath, "w", newline="", encoding="utf-8") as csvfile:
-        writer = csv.writer(csvfile)
-        writer.writerow(fields)
-        for s in stamps:
-            writer.writerow([getattr(s, f) for f in fields])
-
+    stamps: List[Stamp] = session.query(Stamp).all()
+    pdf = FPDF()
+    pdf.set_auto_page_break(auto=True, margin=15)
+    for s in stamps:
+        pdf.add_page()
+        if s.image_path and os.path.exists(s.image_path):
+            pdf.image(s.image_path, w=60)
+        pdf.ln(65)
+        pdf.set_font("Arial", size=12)
+        pdf.cell(0, 10, f"{s.stamp_name or 'Unknown'} - {s.country}", ln=1)
+        pdf.cell(0, 10, f"Denomination: {s.denomination or ''}", ln=1)
+        pdf.multi_cell(0, 10, s.description or "", align="L")
+    filepath = os.path.join(BACKUP_DIR, f"export_{_timestamp()}.pdf")
+    pdf.output(filepath)
     return filepath
-# -------------------------
-# Unified Export (CSV + XLSX)
-# -------------------------
-def export_all():
-    """
-    Export all stamps to both CSV and XLSX and return summary.
-    """
-    csv_path = export_csv()
-    xlsx_path = export_xlsx()
-    return f"Exported: {csv_path} and {xlsx_path}"
-
-
-
-# export_utils.py — Handles CSV and Excel exports for Stamp’d
-
-import os
-import csv
-from datetime import datetime
-from openpyxl import Workbook
-from db_utils import Session, Stamp
-from config import BACKUP_DIR, DB_PATH, IMAGES_DIR
-
-def export_all(format="csv"):
-    session = Session()
-    stamps = session.query(Stamp).all()
-    filename = f"stampd_export_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
-
-    if format == "csv":
-        filepath = os.path.join(BACKUP_DIR, filename + ".csv")
-        with open(filepath, "w", newline='', encoding="utf-8") as f:
-            writer = csv.writer(f)
-            writer.writerow([
-                "ID", "Image Path", "Thumbnail", "Country", "Denomination",
-                "Year", "Color", "Perforation", "Block Type", "Description",
-                "Catalog Number", "Mint/Used", "Lot Number",
-                "Listed", "Listing URL", "Price"
-            ])
-            for s in stamps:
-                writer.writerow([
-                    s.id, s.image_path, s.thumbnail_path, s.country, s.denomination,
-                    s.year, s.color, s.perforation, s.block_type, s.description,
-                    s.catalog_number, s.mint_used, s.lot_number,
-                    s.listed, s.listing_url, s.price
-                ])
-        return filepath
-
-    elif format == "xlsx":
-        filepath = os.path.join(BACKUP_DIR, filename + ".xlsx")
-        wb = Workbook()
-        ws = wb.active
-        ws.append([
-            "ID", "Image Path", "Thumbnail", "Country", "Denomination",
-            "Year", "Color", "Perforation", "Block Type", "Description",
-            "Catalog Number", "Mint/Used", "Lot Number",
-            "Listed", "Listing URL", "Price"
-        ])
-        for s in stamps:
-            ws.append([
-                s.id, s.image_path, s.thumbnail_path, s.country, s.denomination,
-                s.year, s.color, s.perforation, s.block_type, s.description,
-                s.catalog_number, s.mint_used, s.lot_number,
-                s.listed, s.listing_url, s.price
-            ])
-        wb.save(filepath)
-        return filepath
-
-    else:
-        raise ValueError("Unsupported export format")
-
-def auto_backup():
-    if not os.path.exists(BACKUP_DIR):
-        os.makedirs(BACKUP_DIR)
-    export_all("csv")
- 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ gradio==4.26.0
 pytesseract
 Pillow
 numpy
-sqlite3
 openpyxl
 watchdog
 requests
@@ -10,3 +9,5 @@ matplotlib
 scikit-image
 jinja2
 ollama
+fpdf2
+SQLAlchemy

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+os.environ["STAMPD_DB_PATH"] = str(ROOT / "test_export.db")
+
+from db_utils import init_db, insert_stamp, Session, Stamp
+from export_utils import export_csv, export_xlsx, export_pdf
+
+
+def setup_module(module):
+    init_db()
+    session = Session()
+    session.query(Stamp).delete()
+    session.commit()
+    insert_stamp({
+        "image_path": str(ROOT / "images" / "sample_placeholder.jpg"),
+        "stamp_name": "sample",
+        "country": "Unknown",
+        "denomination": "",
+        "description": "test",
+    })
+
+
+def test_export_creates_files():
+    csv_path = export_csv()
+    xlsx_path = export_xlsx()
+    pdf_path = export_pdf()
+    assert os.path.exists(csv_path)
+    assert os.path.exists(xlsx_path)
+    assert os.path.exists(pdf_path)

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+os.environ["STAMPD_DB_PATH"] = str(ROOT / "test_scan.db")
+
+from app import scan_and_sync_folder, save_scans, load_gallery
+from db_utils import Session, Stamp, init_db
+from config import IMAGES_DIR
+
+
+def setup_module(module):
+    init_db()
+    session = Session()
+    session.query(Stamp).delete()
+    session.commit()
+
+
+def test_scan_and_save():
+    # ensure there is at least one image to scan
+    image = os.path.join(IMAGES_DIR, "sample_placeholder.jpg")
+    assert os.path.exists(image)
+    data = scan_and_sync_folder()
+    assert isinstance(data, list)
+    if data:  # may be empty if already scanned
+        save_scans(data)
+    session = Session()
+    assert session.query(Stamp).count() >= 0
+
+
+def test_gallery_load():
+    rows = load_gallery("")
+    assert isinstance(rows, list)

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -27,7 +27,7 @@ def test_scan_and_save():
     if data:  # may be empty if already scanned
         save_scans(data)
     session = Session()
-    assert session.query(Stamp).count() >= 0
+assert session.query(Stamp).count() > 0
 
 
 def test_gallery_load():

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,17 @@
+import sys, pathlib
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from config import load_config, save_config
+
+
+def test_settings_roundtrip():
+    cfg = load_config()
+    original = cfg.get("ai_model")
+    cfg["ai_model"] = "manual"
+    save_config(cfg)
+    new_cfg = load_config()
+    assert new_cfg["ai_model"] == "manual"
+    # restore
+    cfg["ai_model"] = original
+    save_config(cfg)


### PR DESCRIPTION
## Summary
- Refactored configuration to JSON-based settings with dynamic reload and configurable database path
- Implemented Ollama vision metadata generation with fallbacks for offline environments
- Built modular Gradio interface for scanning, gallery management, exporting, and runtime settings
- Added CSV/XLSX/PDF export utilities and basic SQLAlchemy CRUD helpers
- Introduced initial test suite covering settings, scanning, and export flows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e07475fe4832db4fc2e2a5796d6e1